### PR TITLE
Fixes a subpart of #230 : if I put %FIREFOX_HOME%\firefox.exe in my PATH...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -391,6 +391,7 @@
                                             for (candidate : candidates) {
                                                 file = new java.io.File(pathDir, candidate);
                                                 if (file.isFile()) { return true; }
+                                                if(file.getName().equals(candidate)) { return true; }
                                             }
                                         }
                                         return false;


### PR DESCRIPTION
Fixes a subpart of #230 : if I put %FIREFOX_HOME%\firefox.exe in my PATH (instead of %FIREFOX_HOME%), the enforcer rule is not satisfied and the build fail - without any output, but this is another issue.
