### PR TITLE
Fixed bug with i18n services

### DIFF
--- a/framework/i18n-service/src/main/java/org/wisdom/i18n/InternationalizationServiceSingleton.java
+++ b/framework/i18n-service/src/main/java/org/wisdom/i18n/InternationalizationServiceSingleton.java
@@ -244,8 +244,6 @@ public class InternationalizationServiceSingleton implements Internationalizatio
             if (extension.locale().equals(locale)
                     && extension.keys().contains(key)) {
                 return extension;
-            } else if (locale.equals(defaultLocale)  && extension.locale().equals(DEFAULT_LOCALE)) {
-                return extension;
             }
         }
         return null;


### PR DESCRIPTION
Splitting resource budles into multiple files per locale didn't work with default locale.
The default locale retrieval is always done last anyway, the removed check was unwarranted.
