### PR TITLE
Fix agerage -> average typo

### DIFF
--- a/extensions/wisdom-monitor/src/main/java/org/wisdom/monitor/extensions/dashboard/CpuGaugeSet.java
+++ b/extensions/wisdom-monitor/src/main/java/org/wisdom/monitor/extensions/dashboard/CpuGaugeSet.java
@@ -41,7 +41,7 @@ public class CpuGaugeSet implements MetricSet {
     /**
      * The key to retrieve the system load.
      */
-    public static final String SYSTEM_LOAD_AGERAGE = "systemLoadAgerage";
+    public static final String SYSTEM_LOAD_AVERAGE = "systemLoadAverage";
 
     /**
      * The key to retrieve the CPU system load.
@@ -77,7 +77,7 @@ public class CpuGaugeSet implements MetricSet {
                         return bean.getAvailableProcessors();
                     }
                 },
-                SYSTEM_LOAD_AGERAGE, new Gauge<Double>() {
+                SYSTEM_LOAD_AVERAGE, new Gauge<Double>() {
                     /**
                      * @return the average system load.
                      */

--- a/extensions/wisdom-monitor/src/test/java/org/wisdom/monitor/extensions/dashboard/CpuGaugeSetTest.java
+++ b/extensions/wisdom-monitor/src/test/java/org/wisdom/monitor/extensions/dashboard/CpuGaugeSetTest.java
@@ -37,7 +37,7 @@ public class CpuGaugeSetTest {
         assertThat((Integer) ((Gauge) metrics.get(CpuGaugeSet.PROCESSORS)).getValue()).isGreaterThan(0);
         assertThat(((Gauge) metrics.get(CpuGaugeSet.CPU_PROCESS_LOAD)).getValue()).isNotNull();
         assertThat(((Gauge) metrics.get(CpuGaugeSet.CPU_PROCESS_TIME)).getValue()).isNotNull();
-        assertThat(((Gauge) metrics.get(CpuGaugeSet.SYSTEM_LOAD_AGERAGE)).getValue()).isNotNull();
+        assertThat(((Gauge) metrics.get(CpuGaugeSet.SYSTEM_LOAD_AVERAGE)).getValue()).isNotNull();
         assertThat(((Gauge) metrics.get(CpuGaugeSet.CPU_SYSTEM_LOAD)).getValue()).isNotNull();
     }
 }


### PR DESCRIPTION
I suspect that there's concern about metrics changing names, but I hope that's the beauty of being a pre-1.0 version.  Agerage stands out like a sore thumb, even if it's a very understandable fat-fingering.  I appreciate that your library fills in the CPU-shaped gap in CodaHale/DropWizard's metrics, and would love to use it & not have all the ops guys, devs, etc. scratching their heads at me ;)