### PR TITLE
Add source origin in toString of FileWebJarLib.

### DIFF
--- a/framework/resource-controller/src/main/java/org/wisdom/resources/FileWebJarLib.java
+++ b/framework/resource-controller/src/main/java/org/wisdom/resources/FileWebJarLib.java
@@ -21,6 +21,7 @@ package org.wisdom.resources;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.filefilter.TrueFileFilter;
+import org.ow2.chameleon.core.utils.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wisdom.api.configuration.ApplicationConfiguration;
@@ -106,5 +107,10 @@ class FileWebJarLib extends WebJarLib {
         }
     }
 
-
+    @Override
+    public String toString() {
+        if(source != null)
+            return source + "-" + super.toString();
+        return super.toString();
+    }
 }


### PR DESCRIPTION
This will ease the merge of webjars with a same source (useful for webcomponent integration).
Without this commit, webjar with a same source are deployed and merged
but only one webjar is shown in http://localhost:9000/assets (because of the TreeSet Comparator in WebJarController)