### PR TITLE
add support for configuring external url during build

### DIFF
--- a/core/wisdom-maven-plugin/src/main/java/org/wisdom/maven/Constants.java
+++ b/core/wisdom-maven-plugin/src/main/java/org/wisdom/maven/Constants.java
@@ -49,6 +49,8 @@ public interface Constants {
     public static final String TEST_SRC_DIR = "src/test/java";
     public static final String TEST_RESOURCES_DIR = "src/test/resources";
 
+    public static final String NODE_DIST_ROOT_URL = "http://nodejs.org/dist/";
+    public static final String NPM_REGISTRY_ROOT_URL = "https://registry.npmjs.org/";
     public static final String NODE_VERSION = "0.12.4";
     public static final String NODE_VERSION_ARM = "0.10.26";
     public static final String NPM_VERSION = "2.5.1";

--- a/core/wisdom-maven-plugin/src/main/java/org/wisdom/maven/mojos/AbstractWisdomMojo.java
+++ b/core/wisdom-maven-plugin/src/main/java/org/wisdom/maven/mojos/AbstractWisdomMojo.java
@@ -142,7 +142,54 @@ public abstract class AbstractWisdomMojo extends AbstractMojo {
     @Parameter(defaultValue = "${java.home}", required = true, readonly = true)
     public File javaHome;
 
+	
+    /**
+     * The url to download the node distribution.
+     * Default value is 'http://nodejs.org/dist/'.
+     */
+    @Parameter(defaultValue="${nodeDistributionRootUrl}")
+    protected String nodeDistributionRootUrl;
 
+    /**
+     * Gets the root url where the node distribution is downloaded from. Default value is 'http://nodejs.org/dist/' except if the
+     * {@link #nodeDistributionUrl} parameter is configured. In this case,
+     * it returns the url specified by this parameter.
+     *
+     * @return the root url used to download the node distribution.
+     */
+    public String getNodeDistributionRootUrl() {
+        String ret = nodeDistributionRootUrl;
+        if (nodeDistributionRootUrl == null) {
+            ret = Constants.NODE_DIST_ROOT_URL;
+        }
+        
+        return ret;
+    }
+	
+    /**
+     * The root url of the npm registry.
+     * Default value is 'https://registry.npmjs.org/'.
+     */
+    @Parameter(defaultValue="${npmRegistryRootUrl}")
+    protected String npmRegistryRootUrl;
+
+    /**
+     * Gets the root url of the npm registry. Default value is 'https://registry.npmjs.org/' except if the
+     * {@link #npmRegistryRootUrl} parameter is configured. In this case,
+     * it returns the url specified by this parameter.
+     *
+     * @return the root url of the npm registry.
+     */
+    public String getNpmRegistryRootUrl() {
+        String ret = npmRegistryRootUrl;
+        if (npmRegistryRootUrl == null) {
+            ret = Constants.NPM_REGISTRY_ROOT_URL;
+        }
+        
+        return ret;
+    }
+	    
+    
     /**
      * The Node manager.
      */

--- a/core/wisdom-maven-plugin/src/main/java/org/wisdom/maven/mojos/ImageOptimizationMojo.java
+++ b/core/wisdom-maven-plugin/src/main/java/org/wisdom/maven/mojos/ImageOptimizationMojo.java
@@ -89,7 +89,20 @@ public class ImageOptimizationMojo extends AbstractWisdomWatcherMojo implements 
      */
     @Parameter(defaultValue = "${skipImageOptimization}", required = false)
     public boolean skipImageOptimization;
+    
+    /**
+     * The location where the OPTIPNG executable is downloaded.
+     */
+    @Parameter( defaultValue = OPTIPNG_DOWNLOAD_BASE_LOCATION )
+    public String optipngDownloadBaseLocation;
 
+    /**
+     * The location where the JPEGTRAN executable is downloaded.
+     */
+    @Parameter( defaultValue = JPEGTRAN_DOWNLOAD_BASE_LOCATION )
+    public String jpegtranDownloadBaseLocation;
+    
+    
     /**
      * Constructor used by Maven.
      * It sets the installation directory to ~/.wisdom/utils.
@@ -158,15 +171,15 @@ public class ImageOptimizationMojo extends AbstractWisdomWatcherMojo implements 
         // Yeoman has stored binaries on github.
         String url = null;
         if (ExecUtils.isWindows()) {
-            url = OPTIPNG_DOWNLOAD_BASE_LOCATION + "win/optipng.exe";
+            url = optipngDownloadBaseLocation + "win/optipng.exe";
         } else if (ExecUtils.isLinux()) {
             if (ExecUtils.is64bits()) {
-                url = OPTIPNG_DOWNLOAD_BASE_LOCATION + "linux/x64/optipng";
+                url = optipngDownloadBaseLocation + "linux/x64/optipng";
             } else {
-                url = OPTIPNG_DOWNLOAD_BASE_LOCATION + "linux/x86/optipng";
+                url = optipngDownloadBaseLocation + "linux/x86/optipng";
             }
         } else if (ExecUtils.isMac()) {
-            url = OPTIPNG_DOWNLOAD_BASE_LOCATION + "osx/optipng";
+            url = optipngDownloadBaseLocation + "osx/optipng";
         }
 
         if (url == null) {
@@ -220,20 +233,20 @@ public class ImageOptimizationMojo extends AbstractWisdomWatcherMojo implements 
         Map<String, String> urls = new LinkedHashMap<>();
         if (ExecUtils.isWindows()) {
             if (ExecUtils.is64bits()) {
-                urls.put("jpegtran.exe", JPEGTRAN_DOWNLOAD_BASE_LOCATION + "win/x64/jpegtran.exe");
-                urls.put("libjpeg-62.dll", JPEGTRAN_DOWNLOAD_BASE_LOCATION + "win/x64/libjpeg-62.dll");
+                urls.put("jpegtran.exe", jpegtranDownloadBaseLocation + "win/x64/jpegtran.exe");
+                urls.put("libjpeg-62.dll", jpegtranDownloadBaseLocation + "win/x64/libjpeg-62.dll");
             } else {
-                urls.put("jpegtran.exe", JPEGTRAN_DOWNLOAD_BASE_LOCATION + "win/x86/jpegtran.exe");
-                urls.put("libjpeg-62.dll", JPEGTRAN_DOWNLOAD_BASE_LOCATION + "win/x86/libjpeg-62.dll");
+                urls.put("jpegtran.exe", jpegtranDownloadBaseLocation + "win/x86/jpegtran.exe");
+                urls.put("libjpeg-62.dll", jpegtranDownloadBaseLocation + "win/x86/libjpeg-62.dll");
             }
         } else if (ExecUtils.isLinux()) {
             if (ExecUtils.is64bits()) {
-                urls.put("jpegtran", JPEGTRAN_DOWNLOAD_BASE_LOCATION + "linux/x64/jpegtran");
+                urls.put("jpegtran", jpegtranDownloadBaseLocation + "linux/x64/jpegtran");
             } else {
-                urls.put("jpegtran", JPEGTRAN_DOWNLOAD_BASE_LOCATION + "linux/x86/jpegtran");
+                urls.put("jpegtran", jpegtranDownloadBaseLocation + "linux/x86/jpegtran");
             }
         } else if (ExecUtils.isMac()) {
-            urls.put("jpegtran", JPEGTRAN_DOWNLOAD_BASE_LOCATION + "osx/jpegtran");
+            urls.put("jpegtran", jpegtranDownloadBaseLocation + "osx/jpegtran");
         }
 
         getLog().info("Downloading jpegtran from " + urls);

--- a/core/wisdom-maven-plugin/src/main/java/org/wisdom/maven/mojos/InitializeMojo.java
+++ b/core/wisdom-maven-plugin/src/main/java/org/wisdom/maven/mojos/InitializeMojo.java
@@ -33,6 +33,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.Properties;
+import org.wisdom.maven.node.NPM;
 
 /**
  * Mojo preparing the Wisdom runtime.
@@ -152,7 +153,10 @@ public class InitializeMojo extends AbstractWisdomMojo {
         } catch (IOException e) {
             getLog().error("Cannot install node and npm - asset processing won't work", e);
         }
-
+        
+        // Configure NPM registry 
+        NPM.configureRegistry(getNodeManager(), getLog(), (npmRegistryRootUrl==null?Constants.NPM_REGISTRY_ROOT_URL:npmRegistryRootUrl));
+        
         // Prepare OSGi packaging
         try {
             Properties properties = MavenUtils.getDefaultProperties(project);

--- a/core/wisdom-maven-plugin/src/test/java/org/wisdom/maven/mojos/ImageOptimizationMojoTest.java
+++ b/core/wisdom-maven-plugin/src/test/java/org/wisdom/maven/mojos/ImageOptimizationMojoTest.java
@@ -80,6 +80,8 @@ public class ImageOptimizationMojoTest {
         ImageOptimizationMojo mojo = new ImageOptimizationMojo(installation);
         mojo.basedir = basedir;
         mojo.buildDirectory = target;
+        mojo.optipngDownloadBaseLocation = ImageOptimizationMojo.OPTIPNG_DOWNLOAD_BASE_LOCATION;
+        mojo.jpegtranDownloadBaseLocation = ImageOptimizationMojo.JPEGTRAN_DOWNLOAD_BASE_LOCATION;
         mojo.execute();
 
         String optipng = "optipng";


### PR DESCRIPTION
Add support for configuring node distrib url, npm registry, image optimization tools and configure the npm registry of the user.

This allow to build a wisdom project in an environment that doesn't have direct access to internet for security reasons.

Here are the updates included in this pull request:

- Expose the configuration of the node distribution  (default: "http://nodejs.org/dist/")
- Expose the configuration of the npm registry (default: https://registry.npmjs.org/)
- Initialize the registry via the command line: node npm-cli config set registry <npmRegistryRootUrl> in the the initialize mojo (Warning: this updates the `.npmrc` of the user home, maybe a better implementation would be to configure the registry at the node project level)
- Expose the configuration of the optipng tool ( default: https://raw.github.com/yeoman/node-optipng-bin/master/vendor/ )
- Expose the configuration of the jpegtran tool ( default: https://raw.github.com/yeoman/node-jpegtran-bin/master/vendor/ )

These allow us to configure a proxy for node, optipng and jpegtran and use a private npm registry (such as artifactory pro for example)  to manage the npm registry.

Thanks in advance
JB