### PR TITLE
CORS : Replace wildcard with request origin header

### DIFF
--- a/extensions/wisdom-filters/src/main/java/org/wisdom/framework/filters/AbstractCorsFilter.java
+++ b/extensions/wisdom-filters/src/main/java/org/wisdom/framework/filters/AbstractCorsFilter.java
@@ -157,7 +157,7 @@ public abstract class AbstractCorsFilter implements Filter {
     private String getAllowedHostsHeader(final String origin) {
         final List<String> allowedHosts = getAllowedHosts();
         //If wildcard is used, only return the request supplied origin
-        if(allowedHosts.contains("*")){
+        if(getAllowCredentials() && allowedHosts.contains("*")){
             return origin;
         }else {
             return Joiner.on(", ").join(getAllowedHosts());

--- a/extensions/wisdom-filters/src/main/java/org/wisdom/framework/filters/AbstractCorsFilter.java
+++ b/extensions/wisdom-filters/src/main/java/org/wisdom/framework/filters/AbstractCorsFilter.java
@@ -119,7 +119,7 @@ public abstract class AbstractCorsFilter implements Filter {
         // Otherwise we should be return OK with the appropriate headers.
 
         String exposedHeaders = getExposedHeadersHeader();
-        String allowedHosts = getAllowedHostsHeader();
+        String allowedHosts = getAllowedHostsHeader(originHeader);
 
         String allowedMethods = Joiner.on(", ").join(methods);
 
@@ -137,7 +137,7 @@ public abstract class AbstractCorsFilter implements Filter {
 
         // Is it actually a CORS request?
         if (originHeader != null) {
-            String allowedHosts = getAllowedHostsHeader();
+            String allowedHosts = getAllowedHostsHeader(originHeader);
             result = result.with(ACCESS_CONTROL_ALLOW_ORIGIN, allowedHosts);
             if (getAllowCredentials()) {
                 result = result.with(ACCESS_CONTROL_ALLOW_CREDENTIALS, "true");
@@ -154,8 +154,14 @@ public abstract class AbstractCorsFilter implements Filter {
         return Joiner.on(", ").join(getExposedHeaders());
     }
 
-    private String getAllowedHostsHeader() {
-        return Joiner.on(", ").join(getAllowedHosts());
+    private String getAllowedHostsHeader(final String origin) {
+        final List<String> allowedHosts = getAllowedHosts();
+        //If wildcard is used, only return the request supplied origin
+        if(allowedHosts.contains("*")){
+            return origin;
+        }else {
+            return Joiner.on(", ").join(getAllowedHosts());
+        }
     }
 
     /**

--- a/extensions/wisdom-filters/src/test/java/org/wisdom/framework/filters/test/CorsFilterIT.java
+++ b/extensions/wisdom-filters/src/test/java/org/wisdom/framework/filters/test/CorsFilterIT.java
@@ -50,7 +50,7 @@ public class CorsFilterIT extends WisdomBlackBoxTest {
     public void checkThatHeadersAreAddedIfPostRouteExists() throws Exception {
         HttpResponse<String> response = post("/corsTests/post").header(ORIGIN, "http://localhost").asString();
         assertThat(response.code()).isEqualTo(Status.OK);
-        assertThat(response.header(ACCESS_CONTROL_ALLOW_ORIGIN)).isNotNull().contains("*");
+        assertThat(response.header(ACCESS_CONTROL_ALLOW_ORIGIN)).isNotNull().contains("http://localhost");
     }
 
     @Test
@@ -65,7 +65,7 @@ public class CorsFilterIT extends WisdomBlackBoxTest {
         HttpResponse<String> response = new HttpRequestWithBody(HttpMethod.OPTIONS, getHttpURl("/corsTests/post"))
                 .header(ORIGIN, "http://localhost").header(ACCESS_CONTROL_REQUEST_METHOD, "POST").asString();
         assertThat(response.code()).isEqualTo(Status.OK);
-        assertThat(response.header(ACCESS_CONTROL_ALLOW_ORIGIN)).isNotNull().contains("*");
+        assertThat(response.header(ACCESS_CONTROL_ALLOW_ORIGIN)).isNotNull().contains("http://localhost");
     }
 
     @Test
@@ -81,7 +81,7 @@ public class CorsFilterIT extends WisdomBlackBoxTest {
         HttpResponse<String> response = get("/corsTests/get").header(ORIGIN, "http://localhost")
                 .header(ACCESS_CONTROL_REQUEST_METHOD, "GET").asString();
         assertThat(response.code()).isEqualTo(Status.OK);
-        assertThat(response.header(ACCESS_CONTROL_ALLOW_ORIGIN)).isNotNull().contains("*");
+        assertThat(response.header(ACCESS_CONTROL_ALLOW_ORIGIN)).isNotNull().contains("http://localhost");
     }
 
     @Test
@@ -89,7 +89,7 @@ public class CorsFilterIT extends WisdomBlackBoxTest {
         HttpResponse<String> response = new HttpRequestWithBody(HttpMethod.OPTIONS, getHttpURl("/corsTests/get"))
                 .header(ORIGIN, "http://localhost").header(ACCESS_CONTROL_REQUEST_METHOD, "POST").asString();
         assertThat(response.code()).isEqualTo(Status.UNAUTHORIZED);
-        assertThat(response.header(ACCESS_CONTROL_ALLOW_ORIGIN)).isNotNull().contains("*");
+        assertThat(response.header(ACCESS_CONTROL_ALLOW_ORIGIN)).isNotNull().contains("http://localhost");
         assertThat(response.header(ACCESS_CONTROL_ALLOW_METHODS)).contains("GET");
     }
 
@@ -98,7 +98,7 @@ public class CorsFilterIT extends WisdomBlackBoxTest {
         HttpResponse<String> response = new HttpRequestWithBody(HttpMethod.OPTIONS, getHttpURl("/corsTests/get"))
                 .header(ORIGIN, "http://localhost").header(ACCESS_CONTROL_REQUEST_METHOD, "GET").asString();
         assertThat(response.code()).isEqualTo(Status.OK);
-        assertThat(response.header(ACCESS_CONTROL_ALLOW_ORIGIN)).isNotNull().contains("*");
+        assertThat(response.header(ACCESS_CONTROL_ALLOW_ORIGIN)).isNotNull().contains("http://localhost");
         assertThat(response.header(ACCESS_CONTROL_ALLOW_METHODS)).isNotNull().contains("GET");
     }
 
@@ -106,7 +106,7 @@ public class CorsFilterIT extends WisdomBlackBoxTest {
     public void checkThatHeadersAreAddedIfPutRouteExists() throws Exception {
         HttpResponse<String> response = put("/corsTests/put").header(ORIGIN, "http://localhost").asString();
         assertThat(response.code()).isEqualTo(Status.OK);
-        assertThat(response.header(ACCESS_CONTROL_ALLOW_ORIGIN)).isNotNull().contains("*");
+        assertThat(response.header(ACCESS_CONTROL_ALLOW_ORIGIN)).isNotNull().contains("http://localhost");
     }
 
     @Test
@@ -114,7 +114,7 @@ public class CorsFilterIT extends WisdomBlackBoxTest {
         HttpResponse<String> response = new HttpRequestWithBody(HttpMethod.OPTIONS, getHttpURl("/corsTests/put"))
                 .header(ORIGIN, "http://localhost").header(ACCESS_CONTROL_REQUEST_METHOD, "PUT").asString();
         assertThat(response.code()).isEqualTo(Status.OK);
-        assertThat(response.header(ACCESS_CONTROL_ALLOW_ORIGIN)).isNotNull().contains("*");
+        assertThat(response.header(ACCESS_CONTROL_ALLOW_ORIGIN)).isNotNull().contains("http://localhost");
         assertThat(response.header(ACCESS_CONTROL_ALLOW_METHODS)).isNotNull().contains("PUT");
     }
 
@@ -123,7 +123,7 @@ public class CorsFilterIT extends WisdomBlackBoxTest {
         HttpResponse<String> response = new HttpRequestWithBody(HttpMethod.OPTIONS, getHttpURl("/corsTests/postPutGet"))
                 .header(ORIGIN, "http://localhost").header(ACCESS_CONTROL_REQUEST_METHOD, "PUT").asString();
         assertThat(response.code()).isEqualTo(Status.OK);
-        assertThat(response.header(ACCESS_CONTROL_ALLOW_ORIGIN)).isNotNull().contains("*");
+        assertThat(response.header(ACCESS_CONTROL_ALLOW_ORIGIN)).isNotNull().contains("http://localhost");
         assertThat(response.header(ACCESS_CONTROL_ALLOW_METHODS)).isNotNull().contains("PUT", "POST", "GET");
     }
 
@@ -152,7 +152,7 @@ public class CorsFilterIT extends WisdomBlackBoxTest {
                 getHttpURl("/corsTests/dynamic/test")).header(ORIGIN, "http://localhost")
                 .header(ACCESS_CONTROL_REQUEST_METHOD, "POST").asString();
         assertThat(response.code()).isEqualTo(Status.OK);
-        assertThat(response.header(ACCESS_CONTROL_ALLOW_ORIGIN)).isNotNull().contains("*");
+        assertThat(response.header(ACCESS_CONTROL_ALLOW_ORIGIN)).isNotNull().contains("http://localhost");
         assertThat(response.header(ACCESS_CONTROL_ALLOW_METHODS)).isNotNull().contains("POST");
     }
 


### PR DESCRIPTION
Wilcard in CORS configuration will no more result in wildcard in response ACCESS_CONTROL_ALLOW_ORIGIN header. The header value will now be equal to the request ORIGIN header.

Signed-off-by: nicolas-rempulski <nicolas.rempulski@gmail.com>