### PR TITLE
expose threadpool allowCoreThreadTimeOut property in config for ManagedExecutorService

### DIFF
--- a/core/wisdom-executors/src/main/java/org/wisdom/executors/Creator.java
+++ b/core/wisdom-executors/src/main/java/org/wisdom/executors/Creator.java
@@ -124,6 +124,7 @@ public class Creator {
                     5,
                     25,
                     5000,
+                    true,
                     Integer.MAX_VALUE,
                     Thread.NORM_PRIORITY,
                     ecs);

--- a/core/wisdom-executors/src/main/java/org/wisdom/executors/ManagedExecutorServiceImpl.java
+++ b/core/wisdom-executors/src/main/java/org/wisdom/executors/ManagedExecutorServiceImpl.java
@@ -43,6 +43,7 @@ public class ManagedExecutorServiceImpl extends AbstractManagedExecutorService
                 configuration.getIntegerWithDefault("coreSize", 5),
                 configuration.getIntegerWithDefault("maxSize", 25),
                 configuration.getDuration("keepAlive", TimeUnit.MILLISECONDS, 5000),
+                configuration.getBooleanWithDefault("allowCoreThreadTimeOut", true),
                 configuration.getIntegerWithDefault("workQueueCapacity",
                         Integer.MAX_VALUE),
                 configuration.getIntegerWithDefault("priority", Thread.NORM_PRIORITY),
@@ -56,6 +57,7 @@ public class ManagedExecutorServiceImpl extends AbstractManagedExecutorService
             int coreSize,
             int maxSize,
             long keepAlive,
+            boolean allowCoreThreadTimeOut,
             int workQueueCapacity,
             int priority,
             List<ExecutionContextService> ecs) {
@@ -82,7 +84,7 @@ public class ManagedExecutorServiceImpl extends AbstractManagedExecutorService
                 System.out.println("REJECTED EXECUTION : " + r);
             }
         });
-        executor.allowCoreThreadTimeOut(true);
+        executor.allowCoreThreadTimeOut(allowCoreThreadTimeOut);
         setInternalPool(executor);
     }
 

--- a/core/wisdom-executors/src/test/java/org/wisdom/executors/ManagedExecutorServiceImplTest.java
+++ b/core/wisdom-executors/src/test/java/org/wisdom/executors/ManagedExecutorServiceImplTest.java
@@ -48,6 +48,7 @@ public class ManagedExecutorServiceImplTest {
             10,
             25,
             1000,
+            true,
             20,
             Thread.NORM_PRIORITY,
             null);
@@ -328,7 +329,7 @@ public class ManagedExecutorServiceImplTest {
     @Test
     public void testCreationWithUnboundQueue() throws ExecutionException, InterruptedException {
         ManagedExecutorServiceImpl service = new ManagedExecutorServiceImpl("unbound",
-                ManagedExecutorService.ThreadType.POOLED, 60000, 10, 25, 1000,
+                ManagedExecutorService.ThreadType.POOLED, 60000, 10, 25, 1000, true,
                 Integer.MAX_VALUE, Thread.NORM_PRIORITY, null);
         assertThat(service.getQueue()).isInstanceOf(LinkedBlockingQueue.class);
     }
@@ -336,7 +337,7 @@ public class ManagedExecutorServiceImplTest {
     @Test
     public void testCreationWithHandOffQueue() throws ExecutionException, InterruptedException {
         ManagedExecutorServiceImpl service = new ManagedExecutorServiceImpl("unbound",
-                ManagedExecutorService.ThreadType.POOLED, 60000, 10, 25, 1000,
+                ManagedExecutorService.ThreadType.POOLED, 60000, 10, 25, 1000, true,
                 0, Thread.NORM_PRIORITY, null);
         assertThat(service.getQueue()).isInstanceOf(SynchronousQueue.class);
     }


### PR DESCRIPTION
the ManagedExecutorService 's  ThreadPoolExecutor 's allowCoreThreadTimeOut property is set to true by default.
We need it to be configurable