### PR TITLE
Add partial context implementation for WebSocket routes + Security fix

### DIFF
--- a/core/router/src/test/java/org/wisdom/router/WebSocketRouterTest.java
+++ b/core/router/src/test/java/org/wisdom/router/WebSocketRouterTest.java
@@ -124,7 +124,7 @@ public class WebSocketRouterTest {
         assertThat(router.listeners.iterator().next().check()).isTrue();
         assertThat(router.listeners.iterator().next().getController()).isEqualTo(controller);
 
-        router.received("/ws", "client", "hello".getBytes(Charset.defaultCharset()));
+        router.received("/ws", "client", "hello".getBytes(Charset.defaultCharset()), null);
 
         assertThat(message).isEqualTo("hello");
 
@@ -167,7 +167,7 @@ public class WebSocketRouterTest {
         assertThat(router.listeners.iterator().next().check()).isTrue();
         assertThat(router.listeners.iterator().next().getController()).isEqualTo(controller);
 
-        router.received("/ws/foo", "client", "hello".getBytes(Charset.defaultCharset()));
+        router.received("/ws/foo", "client", "hello".getBytes(Charset.defaultCharset()), null);
 
         assertThat(results)
                 .contains(entry("message", "hello"))
@@ -176,7 +176,7 @@ public class WebSocketRouterTest {
 
         results.clear();
 
-        router.received("/ws", "client", "hello".getBytes(Charset.defaultCharset()));
+        router.received("/ws", "client", "hello".getBytes(Charset.defaultCharset()), null);
 
         // Should not have been received.
         assertThat(results).isEmpty();

--- a/core/wisdom-api/src/main/java/org/wisdom/api/http/websockets/WebSocketListener.java
+++ b/core/wisdom-api/src/main/java/org/wisdom/api/http/websockets/WebSocketListener.java
@@ -19,6 +19,8 @@
  */
 package org.wisdom.api.http.websockets;
 
+import org.wisdom.api.http.Context;
+
 /**
  * Classes implementing this interface should register themselves on {@link WebSocketDispatcher} to receive
  * notification when client are opening, closing web sockets or sending data.
@@ -32,7 +34,7 @@ public interface WebSocketListener {
      * @param client  the client id
      * @param content the received content
      */
-    public void received(String uri, String client, byte[] content);
+    public void received(String uri, String client, byte[] content, Context context);
 
     /**
      * Callback invoked when a new client connects on a web socket identified by its url.

--- a/core/wisdom-vertx-engine/src/main/java/org/wisdom/framework/vertx/ContextFromVertx.java
+++ b/core/wisdom-vertx-engine/src/main/java/org/wisdom/framework/vertx/ContextFromVertx.java
@@ -92,6 +92,30 @@ public class ContextFromVertx implements Context {
         }
     }
 
+    /**
+     * Creates a new context with Http headers only, without HttpRequest
+     * This is used to partially initialize the context on WebSocket
+     *
+     * @param accessor a structure containing the used services.
+     * @param headers      the incoming HTTP Headers.
+     */
+    public ContextFromVertx(Vertx vertx, io.vertx.core.Context vertxContext, ServiceAccessor accessor, MultiMap headers) {
+        id = ids.getAndIncrement();
+        services = accessor;
+        request = new RequestFromVertx(headers);
+        this.vertx = vertx;
+        flash = new FlashCookieImpl(accessor.getConfiguration());
+        session = new SessionCookieImpl(accessor.getCrypto(), accessor.getConfiguration());
+        flash.init(this);
+        session.init(this);
+
+        if (vertxContext == null) {
+            throw new IllegalArgumentException("Creating a context from vert.x outside of an event loop");
+        } else {
+            this.vertxContext = vertxContext;
+        }
+    }
+
 
     /**
      * The context id (unique).

--- a/core/wisdom-vertx-engine/src/main/java/org/wisdom/framework/vertx/RequestFromVertx.java
+++ b/core/wisdom-vertx-engine/src/main/java/org/wisdom/framework/vertx/RequestFromVertx.java
@@ -23,9 +23,12 @@ import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.net.MediaType;
+import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
-import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.*;
+import io.vertx.core.http.impl.HttpServerRequestImpl;
+import io.vertx.core.net.NetSocket;
 import io.vertx.core.net.SocketAddress;
 import org.wisdom.api.cookies.Cookie;
 import org.wisdom.api.cookies.Cookies;
@@ -35,6 +38,8 @@ import org.wisdom.api.http.Request;
 import org.wisdom.framework.vertx.cookies.CookiesImpl;
 import org.wisdom.framework.vertx.file.VertxFileUpload;
 
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.security.cert.X509Certificate;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.*;
@@ -73,7 +78,19 @@ public class RequestFromVertx extends Request {
      */
     public RequestFromVertx(final HttpServerRequest request) {
         this.request = request;
-        this.cookies = new CookiesImpl(request);
+        this.cookies = new CookiesImpl(request.headers());
+        this.data = new HashMap<>();
+    }
+
+    /**
+     * Creates a mock {@link org.wisdom.framework.vertx.RequestFromVertx} object from headers
+     * This is used to retrieve cookies information from WebSocket connection
+     *
+     * @param headers Headers from a WebSocket connection
+     */
+    public RequestFromVertx(final MultiMap headers) {
+        this.request = this.mock;
+        this.cookies = new CookiesImpl(headers);
         this.data = new HashMap<>();
     }
 
@@ -594,4 +611,151 @@ public class RequestFromVertx extends Request {
     protected void setRawBody(Buffer raw) {
         this.raw = raw;
     }
+
+    private HttpServerRequest mock = new HttpServerRequest() {
+        @Override
+        public HttpServerRequest exceptionHandler(Handler<Throwable> handler) {
+            return null;
+        }
+
+        @Override
+        public HttpServerRequest handler(Handler<Buffer> handler) {
+            return null;
+        }
+
+        @Override
+        public HttpServerRequest pause() {
+            return null;
+        }
+
+        @Override
+        public HttpServerRequest resume() {
+            return null;
+        }
+
+        @Override
+        public HttpServerRequest endHandler(Handler<Void> handler) {
+            return null;
+        }
+
+        @Override
+        public HttpVersion version() {
+            return null;
+        }
+
+        @Override
+        public HttpMethod method() {
+            return null;
+        }
+
+        @Override
+        public String uri() {
+            return null;
+        }
+
+        @Override
+        public String path() {
+            return null;
+        }
+
+        @Override
+        public String query() {
+            return null;
+        }
+
+        @Override
+        public HttpServerResponse response() {
+            return null;
+        }
+
+        @Override
+        public MultiMap headers() {
+            return null;
+        }
+
+        @Override
+        public String getHeader(String s) {
+            return null;
+        }
+
+        @Override
+        public String getHeader(CharSequence charSequence) {
+            return null;
+        }
+
+        @Override
+        public MultiMap params() {
+            return null;
+        }
+
+        @Override
+        public String getParam(String s) {
+            return null;
+        }
+
+        @Override
+        public SocketAddress remoteAddress() {
+            return null;
+        }
+
+        @Override
+        public SocketAddress localAddress() {
+            return null;
+        }
+
+        @Override
+        public X509Certificate[] peerCertificateChain() throws SSLPeerUnverifiedException {
+            return new X509Certificate[0];
+        }
+
+        @Override
+        public String absoluteURI() {
+            return null;
+        }
+
+        @Override
+        public HttpServerRequest bodyHandler(Handler<Buffer> handler) {
+            return null;
+        }
+
+        @Override
+        public NetSocket netSocket() {
+            return null;
+        }
+
+        @Override
+        public HttpServerRequest setExpectMultipart(boolean b) {
+            return null;
+        }
+
+        @Override
+        public boolean isExpectMultipart() {
+            return false;
+        }
+
+        @Override
+        public HttpServerRequest uploadHandler(Handler<HttpServerFileUpload> handler) {
+            return null;
+        }
+
+        @Override
+        public MultiMap formAttributes() {
+            return null;
+        }
+
+        @Override
+        public String getFormAttribute(String s) {
+            return null;
+        }
+
+        @Override
+        public ServerWebSocket upgrade() {
+            return null;
+        }
+
+        @Override
+        public boolean isEnded() {
+            return false;
+        }
+    };
 }

--- a/core/wisdom-vertx-engine/src/main/java/org/wisdom/framework/vertx/Server.java
+++ b/core/wisdom-vertx-engine/src/main/java/org/wisdom/framework/vertx/Server.java
@@ -288,7 +288,7 @@ public class Server {
 
         http = vertx.createHttpServer(options)
                 .requestHandler(new HttpHandler(vertx, accessor, this))
-                .websocketHandler(new WebSocketHandler(accessor, this));
+                .websocketHandler(new WebSocketHandler(vertx, accessor, this));
 
         http.listen(thePort, host, event -> {
             if (event.succeeded()) {

--- a/core/wisdom-vertx-engine/src/main/java/org/wisdom/framework/vertx/WebSocketHandler.java
+++ b/core/wisdom-vertx-engine/src/main/java/org/wisdom/framework/vertx/WebSocketHandler.java
@@ -20,9 +20,11 @@
 package org.wisdom.framework.vertx;
 
 import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
 import io.vertx.core.http.ServerWebSocket;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.wisdom.api.http.Context;
 
 /**
  * Handles web socket frames.
@@ -38,6 +40,7 @@ public class WebSocketHandler implements Handler<ServerWebSocket> {
      * The structure used to access services.
      */
     private final ServiceAccessor accessor;
+    private final Vertx vertx;
 
     /**
      * The server configuration.
@@ -51,9 +54,10 @@ public class WebSocketHandler implements Handler<ServerWebSocket> {
      * @param server the server configuration - used to check whether or not the message should be
      *                            allowed or denied
      */
-    public WebSocketHandler(ServiceAccessor accessor, Server server) {
+    public WebSocketHandler(Vertx vertx, ServiceAccessor accessor, Server server) {
         this.accessor = accessor;
         this.configuration = server;
+        this.vertx = vertx;
     }
 
     /**
@@ -65,20 +69,31 @@ public class WebSocketHandler implements Handler<ServerWebSocket> {
     public void handle(final ServerWebSocket socket) {
         LOGGER.info("New web socket connection {}, {}", socket, socket.uri());
 
+        final ContextFromVertx context = new ContextFromVertx(vertx, vertx.getOrCreateContext(), accessor, socket.headers());
+
         if (! configuration.accept(socket.uri())) {
             LOGGER.warn("Web Socket connection denied on {} by {}", socket.uri(), configuration.name());
             return;
         }
 
         final Socket sock = new Socket(socket);
+        Context.CONTEXT.set(context);
+        //TODO Propagate context in case listeners use executor on socket opening ?
         accessor.getDispatcher().addSocket(socket.path(), sock);
+        Context.CONTEXT.remove();
 
         socket.closeHandler(event -> {
             LOGGER.info("Web Socket closed {}, {}", socket, socket.uri());
+            Context.CONTEXT.set(context);
+            //TODO Propagate context in case listeners use executor on socket closing ?
             accessor.getDispatcher().removeSocket(socket.path(), sock);
+            Context.CONTEXT.remove();
         });
 
-        socket.handler(event -> accessor.getDispatcher().received(socket.path(), event.getBytes(), sock));
+        socket.handler(event -> {
+            //Context has to be propagated as WebSocketRouter (default WebSocketListener) execute registered routes in an executor
+            accessor.getDispatcher().received(socket.path(), event.getBytes(), sock, context);
+        });
 
     }
 }

--- a/core/wisdom-vertx-engine/src/main/java/org/wisdom/framework/vertx/WisdomVertxServer.java
+++ b/core/wisdom-vertx-engine/src/main/java/org/wisdom/framework/vertx/WisdomVertxServer.java
@@ -439,15 +439,17 @@ public class WisdomVertxServer implements WebSocketDispatcher, WisdomEngine {
      * @param uri     the web socket url
      * @param content the data
      * @param socket  the client channel
+     * @param context the context in which to handle the message
      */
-    public void received(String uri, byte[] content, Socket socket) {
+    public void received(String uri, byte[] content, Socket socket, ContextFromVertx context) {
         List<WebSocketListener> localListeners;
         synchronized (this) {
             localListeners = new ArrayList<>(this.listeners);
         }
 
         for (WebSocketListener listener : localListeners) {
-            listener.received(uri, id(socket), content);
+            //
+            listener.received(uri, id(socket), content, context);
         }
     }
 }

--- a/core/wisdom-vertx-engine/src/main/java/org/wisdom/framework/vertx/cookies/CookiesImpl.java
+++ b/core/wisdom-vertx-engine/src/main/java/org/wisdom/framework/vertx/cookies/CookiesImpl.java
@@ -23,7 +23,10 @@ import com.google.common.collect.Maps;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.cookie.DefaultCookie;
 import io.netty.handler.codec.http.cookie.ServerCookieDecoder;
+import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpServerRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.wisdom.api.cookies.Cookie;
 import org.wisdom.api.cookies.Cookies;
 
@@ -37,9 +40,13 @@ public class CookiesImpl implements Cookies {
 
     private Map<String, Cookie> cookies = Maps.newTreeMap();
 
-    public CookiesImpl(HttpServerRequest request) {
+    /**
+     * Parse cookies from request headers (HttpRequest or WebSocketFrame)
+     * @param headers
+     */
+    public CookiesImpl(MultiMap headers) {
         Set<io.netty.handler.codec.http.cookie.Cookie> localCookies;
-        String value = request.headers().get(HttpHeaders.Names.COOKIE);
+        String value = headers.get(HttpHeaders.Names.COOKIE);
         if (value != null) {
             localCookies = ServerCookieDecoder.LAX.decode(value);
             for (io.netty.handler.codec.http.cookie.Cookie cookie : localCookies) {

--- a/core/wisdom-vertx-engine/src/test/java/org/wisdom/framework/vertx/VertxDispatcherTest.java
+++ b/core/wisdom-vertx-engine/src/test/java/org/wisdom/framework/vertx/VertxDispatcherTest.java
@@ -28,9 +28,9 @@ import org.junit.Test;
 import org.wisdom.api.configuration.ApplicationConfiguration;
 import org.wisdom.api.content.ContentEngine;
 import org.wisdom.api.exceptions.ExceptionMapper;
+import org.wisdom.api.http.Context;
 import org.wisdom.api.http.websockets.WebSocketListener;
 import org.wisdom.api.router.Router;
-import org.wisdom.framework.vertx.ssl.SSLServerContext;
 
 import javax.net.ssl.*;
 import java.io.File;
@@ -189,14 +189,14 @@ public class VertxDispatcherTest extends VertxBaseTest {
         // The listener should have been notified.
         assertThat(listener.opened).isNotNull();
 
-        server.received("/hello", "message".getBytes(Charsets.UTF_8), sock);
+        server.received("/hello", "message".getBytes(Charsets.UTF_8), sock, null);
 
         // The listener should have received the message.
         assertThat(listener.lastMessage).isEqualTo("message");
         assertThat(listener.lastClient).isNotNull();
         assertThat(listener.closed).isNull();
 
-        server.received("/hello", "message2".getBytes(Charsets.UTF_8), sock);
+        server.received("/hello", "message2".getBytes(Charsets.UTF_8), sock, null);
         assertThat(listener.lastMessage).isEqualTo("message2");
         assertThat(listener.lastClient).isNotNull();
         assertThat(listener.closed).isNull();
@@ -223,14 +223,14 @@ public class VertxDispatcherTest extends VertxBaseTest {
         server.addSocket("/hello", sock1);
         // The listener should have been notified.
         assertThat(listener.opened).isNotNull();
-        server.received("/hello", "message".getBytes(Charsets.UTF_8), sock1);
+        server.received("/hello", "message".getBytes(Charsets.UTF_8), sock1, null);
 
         // The listener should have received the message.
         assertThat(listener.lastMessage).isEqualTo("message");
         assertThat(listener.lastClient).isEqualTo(Integer.toOctalString(socket1.hashCode()));
 
         server.addSocket("/hello", sock2);
-        server.received("/hello", "message2".getBytes(Charsets.UTF_8), sock2);
+        server.received("/hello", "message2".getBytes(Charsets.UTF_8), sock2, null);
         assertThat(listener.lastMessage).isEqualTo("message2");
         assertThat(listener.lastClient).isEqualTo(Integer.toOctalString(socket2.hashCode()));
 
@@ -255,7 +255,7 @@ public class VertxDispatcherTest extends VertxBaseTest {
         server.addSocket("/hello", sock);
         // The listener should have been notified.
         assertThat(listener.opened).isNotNull();
-        server.received("/hello", "message".getBytes(Charsets.UTF_8), sock);
+        server.received("/hello", "message".getBytes(Charsets.UTF_8), sock, null);
 
         // The listener should have received the message.
         assertThat(listener.lastMessage).isEqualTo("message");
@@ -310,7 +310,7 @@ public class VertxDispatcherTest extends VertxBaseTest {
         String closed;
 
         @Override
-        public void received(String uri, String client, byte[] content) {
+        public void received(String uri, String client, byte[] content, Context context) {
             this.lastMessage = new String(content, Charsets.UTF_8);
             this.lastClient = client;
         }

--- a/core/wisdom-vertx-engine/src/test/java/org/wisdom/framework/vertx/WebSocketTest.java
+++ b/core/wisdom-vertx-engine/src/test/java/org/wisdom/framework/vertx/WebSocketTest.java
@@ -26,6 +26,7 @@ import org.junit.After;
 import org.junit.Test;
 import org.wisdom.api.configuration.ApplicationConfiguration;
 import org.wisdom.api.exceptions.ExceptionMapper;
+import org.wisdom.api.http.Context;
 import org.wisdom.api.http.websockets.WebSocketListener;
 import org.wisdom.api.router.Router;
 import org.wisdom.framework.vertx.file.DiskFileUpload;
@@ -219,7 +220,7 @@ public class WebSocketTest extends VertxBaseTest {
         }
 
         @Override
-        public void received(String uri, String client, byte[] content) {
+        public void received(String uri, String client, byte[] content, Context context) {
             if (new String(content).equalsIgnoreCase("ping")) {
                 server.send(uri, client, "pong");
             } else {


### PR DESCRIPTION
This one started as a feature request and escalated to a security issue.

The problem arisen when we tried to authenticate user on WebSocket routes (@Open, @Close, @Message) : the authentication failed as Wisdom doesn't use Http headers on Socket to populate the Context available in Controllers (context(), session(), ....).
Several options were possible from there : 

- Create a feature request on Github to use Context on WebSocket Routed :x:
- Implement the feature ourselves  :x:
- Use the WebSocket body / parameters to send the user's sessionId  :x:
- Create the new WebSocket() client side a few milliseconds after a successful authenticated HttpRequest to retrieve user session informations server-side ✅ 
- Stop using WebSo...

? Opening a WebSocket after a HttpRequest allow to retrieve credentials ? Ok, surely some VertX or Wisdom wizardry, let's go onward.

Security issue shred to light when we hit our Proxy (Nginx) timeout that disconnected our WebSockets after 5Mn of inactivyty. 
To solve this issue, when the socket timed-out, we made our client re-establish the WebSocket connection immediatly...
And we tested this feature by hot restarting Nginx while several client had WebSockets opened on our server...
And Wisdom saw each client reconnecting ... as one and only user, all with the same sessionId (same session, same flash, same Context).

It appears that, when a websocket Opening, arrive in the few milliseconds after a HttpRequest, Wisdom mess the Context for the WebSocket Routes and give access to a random Context of a Request currently executed.

This PR intends to fix the security issue by providing Context for WebSocket Routed, using HttpHeaders provided by VertX. This should erase any remaining Context while handling WebSocket events.

Finally, I think there is somewhere a Context release or cleanup that is not correctly done. This did not appear before as the context is always injected in HttpRequest, thus erasing any previous one, but WebSocket, without Context handling, opened a hole in this process.

As it is deep down in Wisdom, I would really like some review before merge.

Thanks !

