### PR TITLE
Made changes to support configuring multiple uri's in Route annotation

### DIFF
--- a/core/wisdom-api/src/main/java/org/wisdom/api/annotations/Route.java
+++ b/core/wisdom-api/src/main/java/org/wisdom/api/annotations/Route.java
@@ -51,7 +51,7 @@ public @interface Route {
      *     </pre>
      * </code>
      */
-    String uri();
+    String[] uri();
 
     /**
      * The list of mime types accepted by the action method. By default, it accepts all content. Specified mime types

--- a/core/wisdom-api/src/main/java/org/wisdom/api/router/RouteUtils.java
+++ b/core/wisdom-api/src/main/java/org/wisdom/api/router/RouteUtils.java
@@ -180,14 +180,16 @@ public class RouteUtils {
         for (Method method : methods) {
             org.wisdom.api.annotations.Route annotation = method.getAnnotation(org.wisdom.api.annotations.Route.class);
             if (annotation != null) {
-                String uri = annotation.uri();
-                uri = getPrefixedUri(prefix, uri);
-                final Route route = new RouteBuilder().route(annotation.method())
-                        .on(uri)
-                        .to(controller, method)
-                        .accepting(annotation.accepts())
-                        .producing(annotation.produces());
-                routes.add(route);
+                String[] uris = annotation.uri();
+                for(String uri: uris) {
+                    uri = getPrefixedUri(prefix, uri);
+                    final Route route = new RouteBuilder().route(annotation.method())
+                            .on(uri)
+                            .to(controller, method)
+                            .accepting(annotation.accepts())
+                            .producing(annotation.produces());
+                    routes.add(route);
+                }
             }
         }
         return routes;

--- a/core/wisdom-maven-plugin/src/main/resources/project/controller/sample/WelcomeController.java
+++ b/core/wisdom-maven-plugin/src/main/resources/project/controller/sample/WelcomeController.java
@@ -45,7 +45,7 @@ public class WelcomeController extends DefaultController {
      *
      * @return the welcome page
      */
-    @Route(method = HttpMethod.GET, uri = "/")
+    @Route(method = HttpMethod.GET, uri = {"/","/index.html"})
     public Result welcome() {
         return ok(render(welcome, "welcome", "Welcome to Wisdom Framework!"));
     }

--- a/core/wisdom-maven-plugin/src/main/resources/project/tests/BlackBoxIT.java
+++ b/core/wisdom-maven-plugin/src/main/resources/project/tests/BlackBoxIT.java
@@ -32,8 +32,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class BlackBoxIT extends WisdomBlackBoxTest {
 
     @Test
-    public void testThatTheWelcomePageIsServed() throws Exception {
+    public void testThatTheWelcomePageIsServedWithRoot() throws Exception {
         HttpResponse<Document> page = get("/").asHtml();
+        assertThat(page.body().title()).isEqualTo("Welcome to Wisdom");
+        assertThat(page.body().getElementsByClass("footer").text()).contains("Wisdom");
+    }
+
+    @Test
+    public void testThatTheWelcomePageIsServedWithIndexDotHtml() throws Exception {
+        HttpResponse<Document> page = get("/index.html").asHtml();
         assertThat(page.body().title()).isEqualTo("Welcome to Wisdom");
         assertThat(page.body().getElementsByClass("footer").text()).contains("Wisdom");
     }

--- a/core/wisdom-maven-plugin/src/main/resources/project/tests/FluentLeniumIT.java
+++ b/core/wisdom-maven-plugin/src/main/resources/project/tests/FluentLeniumIT.java
@@ -31,8 +31,15 @@ import static org.fluentlenium.assertj.FluentLeniumAssertions.assertThat;
 public class FluentLeniumIT extends WisdomFluentLeniumTest {
 
     @Test
-    public void testThatTheWelcomePageContentIsCorrect() {
+    public void testThatTheWelcomePageContentWithRootIsCorrect() {
         goTo("/");
+        assertThat(find(".lead")).hasText("Wisdom is knowing the right " +
+                "path to take. Integrity is taking it.");
+    }
+
+    @Test
+    public void testThatTheWelcomePageContentWithIndexDotHtmlIsCorrect() {
+        goTo("/index.html");
         assertThat(find(".lead")).hasText("Wisdom is knowing the right " +
                 "path to take. Integrity is taking it.");
     }


### PR DESCRIPTION
Made changes to support configuring multiple uri's in Route annotation. This request was mainly to configure multiple URI paths to the same action method. 

``
/**
     * The action method returning the welcome page. It handles
     * HTTP GET request on the "/" URL.
     *
     * @return the welcome page
     */
    @Route(method = HttpMethod.GET, uri = {"/","/index.html"})
    public Result welcome() {
        logger.info("Welcome action being served");
        return ok(render(welcome, "welcome", "Welcome to Wisdom Framework!"));
